### PR TITLE
Add configurable tracks data path

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -2,6 +2,7 @@ zenmap:
   server:
     host: 0.0.0.0
     port: 8080
+  tracksDataFile: tracks_data.json
 
 database:
   neo4j:

--- a/src/main/java/dev/joordih/zenmap/managers/config/impl/ZenmapConfiguration.java
+++ b/src/main/java/dev/joordih/zenmap/managers/config/impl/ZenmapConfiguration.java
@@ -13,6 +13,10 @@ public class ZenmapConfiguration extends ConfigSection {
     return new ZenmapServerConfig(config);
   }
 
+  public String getTracksDataFile() {
+    return config.getString(getKey("tracksDataFile"));
+  }
+
   public static class ZenmapServerConfig extends ConfigSection {
     public ZenmapServerConfig(Configuration config) {
       super(config, "zenmap.server");

--- a/src/main/java/dev/joordih/zenmap/managers/nodes/track/TrackStrategy.java
+++ b/src/main/java/dev/joordih/zenmap/managers/nodes/track/TrackStrategy.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import dev.joordih.zenmap.managers.nodes.lane.Lane;
+import dev.joordih.zenmap.Zenmap;
 import dev.joordih.zenmap.managers.providers.impl.Neo4jProvider;
 import dev.joordih.zenmap.managers.repository.NeoObjectRepository;
 import dev.joordih.zenmap.managers.strategy.StrategyFactory;
@@ -32,7 +33,9 @@ import java.util.stream.Collectors;
 @Getter
 public class TrackStrategy {
   private static final Logger LOGGER = Logger.getLogger(TrackStrategy.class.getName());
-  private static final String TRACKS_JSON_FILE = "tracks_data.json";
+
+  private static final String DEFAULT_TRACKS_JSON_FILE = "tracks_data.json";
+  private final String tracksDataFile;
 
   private final Neo4jProvider provider;
   private final Session session;
@@ -42,6 +45,16 @@ public class TrackStrategy {
     this.provider = provider;
     this.session = session;
     this.trackRepository = new NeoObjectRepository<>(session, Track.class);
+
+    String configPath = Zenmap.getInstance()
+        .getConfigFactory()
+        .getZenmapConfiguration()
+        .getTracksDataFile();
+    if (configPath == null || configPath.isBlank()) {
+      this.tracksDataFile = DEFAULT_TRACKS_JSON_FILE;
+    } else {
+      this.tracksDataFile = configPath;
+    }
 
     LOGGER.info("------------------------------");
     LOGGER.info("Loading tracks...");
@@ -61,7 +74,13 @@ public class TrackStrategy {
 
   private void importTracksFromJson() {
     try {
-      File jsonFile = new File(TRACKS_JSON_FILE);
+      Path filePath = Paths.get(tracksDataFile);
+      if (!Files.exists(filePath)) {
+        LOGGER.severe("Tracks data file not found at: " + filePath.toAbsolutePath());
+        return;
+      }
+
+      File jsonFile = filePath.toFile();
       ObjectMapper objectMapper = JsonUtils.getMAPPER();
 
       JsonNode rootNode = objectMapper.readTree(jsonFile);
@@ -210,7 +229,7 @@ public class TrackStrategy {
 
     try {
       Gson gson = new GsonBuilder().setPrettyPrinting().create();
-      Path filePath = Paths.get(TRACKS_JSON_FILE);
+      Path filePath = Paths.get(tracksDataFile);
 
       List<Track> allTracks = new ArrayList<>(tracks);
       if (Files.exists(filePath)) {

--- a/src/main/java/dev/joordih/zenmap/sdk/config/ConfigFileManager.java
+++ b/src/main/java/dev/joordih/zenmap/sdk/config/ConfigFileManager.java
@@ -33,7 +33,8 @@ public class ConfigFileManager {
           server:
             host: 0.0.0.0
             port: 8080
-        
+          tracksDataFile: tracks_data.json
+
         database:
           neo4j:
             uri: neo4j://localhost:7687


### PR DESCRIPTION
## Summary
- make path for `tracks_data.json` configurable through `settings.yml`
- expose `zenmap.tracksDataFile` setting via `ZenmapConfiguration`
- update default config file generator
- load path in `TrackStrategy` and validate file exists before reading

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6840095a18b4832da77baf41f2e27c2f